### PR TITLE
Add `path.resolve` Check to Prevent Path Traversal

### DIFF
--- a/web_admin/cmd_utils.js
+++ b/web_admin/cmd_utils.js
@@ -318,7 +318,10 @@ exports.get_logfile = async function (req, res) {
     var logpath = config.binpath + "log";   
     co(function*(){
         if ( req.query["name"] ) {
-            var logfile = logpath + '/' + req.query["name"];
+            var logfile = path.resolve(logpath + '/' + req.query["name"]);
+	    if (!logfile.startsWith(logpath)) {
+	    	fail_response ( res, 'file not found' );
+	    }
             if (fs.existsSync(logfile)) {
                 fs.readFile(logfile, (err, data) => {
                     if (err) {


### PR DESCRIPTION
This PR adds a `path.resolve` check to mitigate path traversal vulnerabilities. Previously, user-controlled input could potentially allow unauthorized file access by using `../` sequences.